### PR TITLE
Handle asset source being a buffer, not a string

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,8 +25,9 @@ InlineManifestPlugin.prototype.apply = function (compiler) {
             })[0] || {files: []}).files[0];
 
             if (manifestPath) {
+                const source = sourceMappingURL.removeFrom(compilation.assets[manifestPath].source().toString());
                 webpackManifest.push('<script>');
-                webpackManifest.push(sourceMappingURL.removeFrom(compilation.assets[manifestPath].source()));
+                webpackManifest.push(source);
                 webpackManifest.push('</script>');
 
                 const manifestIndex = assets.js.indexOf(assets.publicPath + manifestPath);


### PR DESCRIPTION
I am still trying to track down _why_ this happens, but when doing a production build `source()` returns a `Buffer` instead of a string. It seems to be fine in development, so my intuition is that it's minification related, but I haven't been able to isolate exactly which option. Changing `mode`, disabling the Uglify plugin - nothing seems to alter how this works in a production build.

Example in production build (output of `typeof compilation.assets[manifestPath].source()`):

`type of source: object`

vs dev

`type of source: string`